### PR TITLE
Using blocks with WebMock's matcher have_requested..with

### DIFF
--- a/spec/channel_spec.rb
+++ b/spec/channel_spec.rb
@@ -41,7 +41,7 @@ describe Pusher::Channel do
         :name => 'Pusher',
         :last_name => 'App'
       })
-      WebMock.should have_requested(:post, %r{/apps/20/channels/test_channel/events}).with do |req|
+      WebMock.should have_requested(:post, %r{/apps/20/channels/test_channel/events}).with { |req|
         query_hash = req.uri.query_values
         query_hash["name"].should == 'new_event'
         query_hash["auth_key"].should == @client.key
@@ -54,15 +54,13 @@ describe Pusher::Channel do
         }
 
         req.headers['Content-Type'].should == 'application/json'
-      end
+      }
     end
 
     it "should POST string data unmodified in request body" do
       string = "foo\nbar\""
       @channel.trigger!('new_event', string)
-      WebMock.should have_requested(:post, %r{/apps/20/channels/test_channel/events}).with do |req|
-        req.body.should == "foo\nbar\""
-      end
+      WebMock.should have_requested(:post, %r{/apps/20/channels/test_channel/events}).with { |req| req.body.should == "foo\nbar\"" }
     end
 
     it "should catch all Net::HTTP exceptions and raise a Pusher::HTTPError, exposing the original error if required" do


### PR DESCRIPTION
Hey Guys,

Using WebMock's have_request matcher in this way:

```
WebMock.should have_requested(..).with do |req| ... end
```

it is skipping the code you have inside. This happens because the {} has higher syntactic precedence than the do..end, so the block do..end it's been sent to the method "have_requested" instead of the method "with" (that is the one who should receive the block), but if you change by {} then this block is caught by the "with" method.
