### PR TITLE
Fixed incorrect exception thrown for missing EM

### DIFF
--- a/lib/pusher/request.rb
+++ b/lib/pusher/request.rb
@@ -53,9 +53,9 @@ module Pusher
     end
 
     def send_async
+      http_client = @client.em_http_client(@uri)
       df = EM::DefaultDeferrable.new
 
-      http_client = @client.em_http_client(@uri)
       http = case @verb
       when :post
         http_client.post({


### PR DESCRIPTION
The `Client#em_http_client` method checks whether EventMachine is available. However, the `#send_async` method tries to create an instance of `EM::DefaultDeferrable` before this check, which causes `NameError: uninitialized constant Pusher::Request::EM` instead of expected exception `Pusher::Error: In order to use async calling you must be running inside an eventmachine loop`.
