### PR TITLE
Update readme to show correct trigger_async params

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ When using an asynchronous version of a method, it will return a deferrable.
 
     Pusher.trigger_async(['a_channel'], 'an_event', {
       :some => 'data'
-    }, socket_id).callback {
+    }, { 
+      :socket_id => socket_id
+    }).callback {
       # Do something on success
     }.errback { |error|
       # error is a instance of Pusher::Error


### PR DESCRIPTION
We were getting undefined method merge errors when using trigger_async - realised the code is now expecting a hash for socket_id instead of a string.
