### PR TITLE
Removed script line from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,3 @@ matrix:
   allow_failures:
     - rvm: jruby-18mode
     - rvm: jruby-19mode
-
-script: "rspec spec/*_spec.rb"


### PR DESCRIPTION
Travis CI automatically executes `rake` for Ruby projects. As the Rakefile is configured to run the tests for the `default` command, removing the `script` line should allow the tests to run.
