### PR TITLE
Allow httpclient 2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     pusher (0.12.0)
-      httpclient (~> 2.3.0)
+      httpclient (~> 2.4.0)
       multi_json (~> 1.0)
       signature (~> 0.1.6)
 
@@ -24,8 +24,8 @@ GEM
       eventmachine (>= 1.0.0.beta.4)
     eventmachine (1.0.3)
     http_parser.rb (0.6.0.beta.2)
-    httpclient (2.3.4.1)
-    multi_json (1.7.8)
+    httpclient (2.4.0)
+    multi_json (1.10.1)
     rack (1.5.2)
     rake (10.1.0)
     rspec (2.14.1)

--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency 'signature', "~> 0.1.6"
-  s.add_dependency "httpclient", "~> 2.3.0"
+  s.add_dependency "httpclient", "~> 2.3"
   s.add_dependency "jruby-openssl" if defined?(JRUBY_VERSION)
 
   s.add_development_dependency "rspec", "~> 2.0"


### PR DESCRIPTION
Follow up to #57. Sorry for making trouble :bow: 

> Do you know if httpclient follows semantic versioning ? Maybe the selector should be widened to ~2.0 so existing users aren't forced to upgrade. There's a common issue where gem A depends on 2.3.0 and B on 2.4.0 and the user of both is blocked.

As I see, httpclient seems to be following semvar(https://github.com/nahi/httpclient#changes).
And also, author of httpclient is an open source veteran, so I think he won't introduce breaking changes on minor update.
