### PR TITLE
Fix limited channel count at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Errors are logged to `Pusher.logger`. It will by default log at info level to ST
 
 ### Publishing events
 
-An event can be published to one or more channels (limited to 100) in one API call:
+An event can be published to one or more channels (limited to 10) in one API call:
 
     Pusher.trigger('channel', 'event', {foo: 'bar'})
     Pusher.trigger(['channel_1', 'channel_2'], 'event_name', {foo: 'bar'})


### PR DESCRIPTION
The correct count is `10`: http://pusher.com/docs/rest_api#method-post-event
