### PR TITLE
Pusher gem don't work with httpclient 2.5.3

### DIFF
--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency 'signature', "~> 0.1.6"
-  s.add_dependency "httpclient", "~> 2.4"
+  s.add_dependency "httpclient", "~> 2.4", '< 2.5.3'
   s.add_dependency "jruby-openssl" if defined?(JRUBY_VERSION)
 
   s.add_development_dependency "rspec", "~> 2.0"


### PR DESCRIPTION
Due to `'~> 2.4'` restriction you have we accidentally upgraded to 2.3.5.1 of httpclient today and it doesn't work with pusher gem.

> SocketError: getaddrinfo: Temporary failure in name resolution (https://api.pusherapp.com:443)