### PR TITLE
Bump httpclient version from 2.4 to 2.5

### DIFF
--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency 'signature', "~> 0.1.6"
-  s.add_dependency "httpclient", "~> 2.4"
+  s.add_dependency "httpclient", "~> 2.5"
   s.add_dependency "jruby-openssl" if defined?(JRUBY_VERSION)
 
   s.add_development_dependency "rspec", "~> 2.0"


### PR DESCRIPTION
Bumped the httpclient gem version from 2.4 to 2.5 in order to have SSLv3 fully disabled.
