### PR TITLE
Fix warning message for `.raise_error` matcher

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -135,7 +135,7 @@ describe Pusher do
       end
 
       it "should fail on bad urls" do
-        expect { @client.url = "gopher/somekey:somesecret@://api.staging.pusherapp.co://m:8080\apps\87" }.to raise_error
+        expect { @client.url = "gopher/somekey:somesecret@://api.staging.pusherapp.co://m:8080\apps\87" }.to raise_error(URI::InvalidURIError)
       end
     end
 


### PR DESCRIPTION
This addresses the issue where RSpec throws a warning for using the
`.raise_error` matcher without a specific error.