### PR TITLE
Ensure configuration exists

### DIFF
--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -119,7 +119,9 @@ module Pusher
     # @raise [Pusher::HTTPError] Error raised inside http client. The original error is wrapped in error.original_error
     #
     def get(path, params = {})
-      Resource.new(self, path).get(params)
+      with_ensured_configuration do
+        resource(path).get(params)
+      end
     end
 
     # GET arbitrary REST API resource using an asynchronous http client.
@@ -135,20 +137,26 @@ module Pusher
     # @return Either an EM::DefaultDeferrable or a HTTPClient::Connection
     #
     def get_async(path, params = {})
-      Resource.new(self, path).get_async(params)
+      with_ensured_configuration do
+        resource(path).get_async(params)
+      end
     end
 
     # POST arbitrary REST API resource using a synchronous http client.
     # Works identially to get method, but posts params as JSON in post body.
     def post(path, params = {})
-      Resource.new(self, path).post(params)
+      with_ensured_configuration do
+        resource(path).post(params)
+      end
     end
 
     # POST arbitrary REST API resource using an asynchronous http client.
     # Works identially to get_async method, but posts params as JSON in post
     # body.
     def post_async(path, params = {})
-      Resource.new(self, path).post_async(params)
+      with_ensured_configuration do
+        resource(path).post_async(params)
+      end
     end
 
     ## HELPER METHODS ##
@@ -172,8 +180,9 @@ module Pusher
     #   should not contain anything other than letters, numbers, or the
     #   characters "_\-=@,.;"
     def channel(channel_name)
-      raise ConfigurationError, 'Missing client configuration: please check that key, secret and app_id are configured.' unless configured?
-      Channel.new(url, channel_name, self)
+      with_ensured_configuration do
+        Channel.new(url, channel_name, self)
+      end
     end
 
     alias :[] :channel
@@ -304,6 +313,14 @@ module Pusher
 
     def configured?
       host && scheme && key && secret && app_id
+    end
+
+    def with_ensured_configuration
+      unless configured?
+        raise ConfigurationError, "Missing client configuration: please check that key, secret and app_id are configured."
+      end
+
+      yield
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -309,6 +309,11 @@ describe Pusher do
 
           let(:call_api) { @client.send(verb, '/path') }
 
+          it "raises an exception if not configured properly" do
+            @client.secret = nil
+            expect { call_api }.to raise_error(Pusher::ConfigurationError)
+          end
+
           it "should use http by default" do
             call_api
             expect(WebMock).to have_requested(verb, %r{http://api.pusherapp.com/apps/20/path})
@@ -391,6 +396,11 @@ describe Pusher do
               }
             }
 
+            it "raises an exception if not configured properly" do
+              @client.secret = nil
+              expect { call_api }.to raise_error(Pusher::ConfigurationError)
+            end
+
             it "should use http by default" do
               call_api
               expect(WebMock).to have_requested(verb, %r{http://api.pusherapp.com/apps/20/path})
@@ -425,6 +435,11 @@ describe Pusher do
             end
 
             let(:call_api) { @client.send(method, '/path') }
+
+            it "raises an exception if not configured properly" do
+              @client.secret = nil
+              expect { call_api }.to raise_error(Pusher::ConfigurationError)
+            end
 
             it "should use http by default" do
               EM.run {


### PR DESCRIPTION
Currently, if important parts of the configuration is missing such as
key, secret or app_id the client will blow up when trying to reference
any of the attributes. An example of this would be executing a `#get`
request and building the proper signature. Since the attributes can be
`nil` we would get an error such as: "Can't convert nil to string".

I'm not super familiar with the library yet, so I may have overlooked certain aspects of the library. If I missed any methods that should be covered by `with_ensure_configuration` feel free to call it out. I'd be happy to adjust the pull request accordingly.