### PR TITLE
Use pusher-signature instead of signature gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.14.6 / 2015-09-29
+==================
+  * Updated to use the `pusher-signature` gem instead of `signature`.
+    This resolves namespace related issues.
 
 0.14.5 / 2015-05-11
 ==================

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -1,4 +1,4 @@
-require 'signature'
+require 'pusher-signature'
 
 module Pusher
   class Client
@@ -30,7 +30,7 @@ module Pusher
 
     # @private Returns the authentication token for the client
     def authentication_token
-      Signature::Token.new(@key, @secret)
+      Pusher::Signature::Token.new(@key, @secret)
     end
 
     # @private Builds a url for this app, optionally appending a path

--- a/lib/pusher/request.rb
+++ b/lib/pusher/request.rb
@@ -1,4 +1,4 @@
-require 'signature'
+require 'pusher-signature'
 require 'digest/md5'
 require 'multi_json'
 
@@ -16,7 +16,7 @@ module Pusher
         @head['Content-Type'] = 'application/json'
       end
 
-      request = Signature::Request.new(verb.to_s.upcase, uri.path, params)
+      request = Pusher::Signature::Request.new(verb.to_s.upcase, uri.path, params)
       request.sign(client.authentication_token)
       @params = request.signed_params
     end

--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.add_dependency "multi_json", "~> 1.0"
-  s.add_dependency 'signature', "~> 0.1.8"
+  s.add_dependency 'pusher-signature', "~> 0.1.8"
   s.add_dependency "httpclient", "~> 2.5"
   s.add_dependency "jruby-openssl" if defined?(JRUBY_VERSION)
 


### PR DESCRIPTION
@zimbatm 

Updated all occurrences of `Signature` to use `Pusher::Signature`.
Now uses `pusher-signature` instead of `signature` gem.
