### PR TITLE
Add `Pusher.authenticate` for authing on channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ It's possible to use the gem to authenticate subscription requests to private or
 ### Private channels
 
 ``` ruby
-Pusher['private-my_channel'].authenticate(params[:socket_id])
+Pusher.authenticate('private-my_channel', params[:socket_id])
 ```
 
 ### Presence channels
@@ -186,7 +186,7 @@ Pusher['private-my_channel'].authenticate(params[:socket_id])
 These work in a very similar way, but require a unique identifier for the user being authenticated, and optionally some attributes that are provided to clients via presence events:
 
 ``` ruby
-Pusher['presence-my_channel'].authenticate(params[:socket_id], {
+Pusher.authenticate('presence-my_channel', params[:socket_id], {
   user_id: 'user_id',
   user_info: {} # optional
 })

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -235,6 +235,33 @@ module Pusher
       post_async('/events', trigger_params(channels, event_name, data, params))
     end
 
+    # Generate the expected response for an authentication endpoint.
+    # See http://pusher.com/docs/authenticating_users for details.
+    #
+    # @example Private channels
+    #   render :json => Pusher.authenticate('private-my_channel', params[:socket_id])
+    #
+    # @example Presence channels
+    #   render :json => Pusher.authenticate('presence-my_channel', params[:socket_id], {
+    #     :user_id => current_user.id, # => required
+    #     :user_info => { # => optional - for example
+    #       :name => current_user.name,
+    #       :email => current_user.email
+    #     }
+    #   })
+    #
+    # @param socket_id [String]
+    # @param custom_data [Hash] used for example by private channels
+    #
+    # @return [Hash]
+    #
+    # @private Custom data is sent to server as JSON-encoded string
+    #
+    def authenticate(channel_name, socket_id, custom_data = nil)
+      channel_instance = channel(channel_name)
+      channel_instance.authenticate(socket_id, custom_data)
+    end
+
     # @private Construct a net/http http client
     def sync_http_client
       @client ||= begin

--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "em-http-request", "~> 1.1.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rack"
+  s.add_development_dependency "json"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -128,6 +128,24 @@ describe Pusher do
         end
       end
 
+      describe '#authenticate' do
+        before :each do
+          @custom_data = {:uid => 123, :info => {:name => 'Foo'}}
+        end
+
+        it 'should return a hash with signature including custom data and data as json string' do
+          allow(MultiJson).to receive(:encode).with(@custom_data).and_return 'a json string'
+
+          response = @client.authenticate('test_channel', '1.1', @custom_data)
+
+          expect(response).to eq({
+            :auth => "12345678900000001:#{hmac(@client.secret, "1.1:test_channel:a json string")}",
+            :channel_data => 'a json string'
+          })
+        end
+
+      end
+
       describe '#trigger' do
         before :each do
           @api_path = %r{/apps/20/events}


### PR DESCRIPTION
This brings the API inline with `Pusher.trigger`, rather than having to
use the now deprecated `Pusher[name].authenticate(...)` style. The APIs
aren't quite 1-1 as `Pusher.authenticate` only takes a single channel
name, rather than 1-N channel names. That can come in a further PR.

@hamchapman what do you think? Would be nice to bring `authenticate` to parity with `trigger` and let it take multiple channel names, but might tackle that in a subsequent PR.