### PR TITLE
Expose the #authenticate module on Pusher

### DIFF
--- a/lib/pusher.rb
+++ b/lib/pusher.rb
@@ -32,7 +32,7 @@ module Pusher
 
     def_delegators :default_client, :get, :get_async, :post, :post_async
     def_delegators :default_client, :channels, :channel_info, :trigger, :trigger_async
-    def_delegators :default_client, :webhook, :channel, :[]
+    def_delegators :default_client, :authenticate, :webhook, :channel, :[]
 
     attr_writer :logger
 


### PR DESCRIPTION
I forgot to expose the new `authenticate` module I added. This adds it so people can actually use `Pusher.authenticate`.