### PR TITLE
Bump httpclient version to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.0
   - jruby-18mode
   - jruby-19mode
   - rbx-2
 
 matrix:
   allow_failures:
+    - rmv: 1.9.2
     - rvm: jruby-18mode
     - rvm: jruby-19mode
     - rvm: rbx-2

--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency 'pusher-signature', "~> 0.1.8"
-  s.add_dependency "httpclient", "~> 2.5"
+  s.add_dependency "httpclient", "~> 2.7"
   s.add_dependency "jruby-openssl" if defined?(JRUBY_VERSION)
 
   s.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Removes deprecation warnings when using with Ruby 2.3.0.

Can see more changes here: https://github.com/nahi/httpclient/blob/master/CHANGELOG.md