### PR TITLE
Added client batch methods to default client delegations

### DIFF
--- a/lib/pusher.rb
+++ b/lib/pusher.rb
@@ -37,7 +37,8 @@ module Pusher
     def_delegators :default_client, :timeout=, :connect_timeout=, :send_timeout=, :receive_timeout=, :keep_alive_timeout=
 
     def_delegators :default_client, :get, :get_async, :post, :post_async
-    def_delegators :default_client, :channels, :channel_info, :channel_users, :trigger, :trigger_async
+    def_delegators :default_client, :channels, :channel_info, :channel_users
+    def_delegators :default_client, :trigger, :trigger_batch, :trigger_async, :trigger_batch_async
     def_delegators :default_client, :authenticate, :webhook, :channel, :[]
     def_delegators :default_client, :notify
 


### PR DESCRIPTION
I ran into an error today claiming "trigger_batch" was not a method for Pusher:Module. Turns out the batch trigger methods were never added to the delegations to the default client.