### PR TITLE
Make `Pusher.trigger_batch` work

### DIFF
--- a/lib/pusher.rb
+++ b/lib/pusher.rb
@@ -37,7 +37,9 @@ module Pusher
     def_delegators :default_client, :timeout=, :connect_timeout=, :send_timeout=, :receive_timeout=, :keep_alive_timeout=
 
     def_delegators :default_client, :get, :get_async, :post, :post_async
-    def_delegators :default_client, :channels, :channel_info, :channel_users, :trigger, :trigger_async
+    def_delegators :default_client, :channels, :channel_info, :channel_users, :trigger, :trigger_async, :trigger_batch, 
+                                    :trigger_batch_async
+    
     def_delegators :default_client, :authenticate, :webhook, :channel, :[]
     def_delegators :default_client, :notify
 


### PR DESCRIPTION
Add the behaviour described in the readme:
https://github.com/pusher/pusher-http-ruby/commit/7fced7f7e3d79e59b5ac6fd53e3b4ad030f4fbe9#diff-04c6e90faac2675aa89e2176d2eec7d8

Edit: I just found https://github.com/pusher/pusher-http-ruby/pull/109