### PR TITLE
Prep v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.3.1 / 2017-03-15
+==================
+
+  * Added missing client batch methods to default client delegations
+  * Document raised exception in the `authenticate` method
+  * Fixes em-http-request from using v2.5.0 of `addressable` breaking builds.
 
 1.3.0 / 2016-08-23
 ==================

--- a/lib/pusher.rb
+++ b/lib/pusher.rb
@@ -37,7 +37,8 @@ module Pusher
     def_delegators :default_client, :timeout=, :connect_timeout=, :send_timeout=, :receive_timeout=, :keep_alive_timeout=
 
     def_delegators :default_client, :get, :get_async, :post, :post_async
-    def_delegators :default_client, :channels, :channel_info, :channel_users, :trigger, :trigger_async
+    def_delegators :default_client, :channels, :channel_info, :channel_users
+    def_delegators :default_client, :trigger, :trigger_batch, :trigger_async, :trigger_batch_async
     def_delegators :default_client, :authenticate, :webhook, :channel, :[]
     def_delegators :default_client, :notify
 

--- a/lib/pusher/channel.rb
+++ b/lib/pusher/channel.rb
@@ -120,6 +120,8 @@ module Pusher
     # @param custom_string [String] Allows signing additional data
     # @return [String]
     #
+    # @raise [Pusher::Error] if socket_id or custom_string invalid
+    #
     def authentication_string(socket_id, custom_string = nil)
       validate_socket_id(socket_id)
 
@@ -156,6 +158,8 @@ module Pusher
     # @param custom_data [Hash] used for example by private channels
     #
     # @return [Hash]
+    #
+    # @raise [Pusher::Error] if socket_id or custom_data is invalid
     #
     # @private Custom data is sent to server as JSON-encoded string
     #

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -345,6 +345,8 @@ module Pusher
     #
     # @return [Hash]
     #
+    # @raise [Pusher::Error] if channel_name or socket_id are invalid
+    #
     # @private Custom data is sent to server as JSON-encoded string
     #
     def authenticate(channel_name, socket_id, custom_data = nil)

--- a/lib/pusher/version.rb
+++ b/lib/pusher/version.rb
@@ -1,3 +1,3 @@
 module Pusher
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end

--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "webmock"
   s.add_development_dependency "em-http-request", "~> 1.1.0"
+  s.add_development_dependency "addressable", "=2.4.0"
   s.add_development_dependency "rake", "~> 10.4.2"
   s.add_development_dependency "rack", "~> 1.6.4"
   s.add_development_dependency "json", "~> 1.8.3"


### PR DESCRIPTION
Merged in changes from #109 and #112.

Also locked in version of `addressable` to `2.4.0` as `2.5.0` requires the `public_suffix` gem which requires ruby > 2.0.

A later `2.0` release dropping support for ruby `1.9` will follow.

EDIT: Wrong branch name. The version is `1.3.1`

@hamchapman WDYT?