### PR TITLE
Declare em-http-request as a runtime dep

### DIFF
--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |s|
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency 'pusher-signature', "~> 0.1.8"
   s.add_dependency "httpclient", "~> 2.7"
+  s.add_dependency "em-http-request", "~> 1.1.0"
   s.add_dependency "jruby-openssl" if defined?(JRUBY_VERSION)
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "webmock"
-  s.add_development_dependency "em-http-request", "~> 1.1.0"
   s.add_development_dependency "addressable", "=2.4.0"
   s.add_development_dependency "rake", "~> 10.4.2"
   s.add_development_dependency "rack", "~> 1.6.4"


### PR DESCRIPTION
Pusher require em-http-request:

https://github.com/pusher/pusher-http-ruby/blob/adf04980682264050e70b99dd39dc8b82af2390a/lib/pusher/client.rb#L377

but it is only specified as a development dependency meaning it is not installed when a bundle install is done in a project that includes it. This means em-http-request has to be explicitly added to the Gemfile of a project.

This PR changes it to a regular runtime dependency so Bundler knows about it and can install the correct version as required.