### PR TITLE
Correcting Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ events per call on multi-tenant clusters):
 
 ``` ruby
 Pusher.trigger_batch([
-  {channel: 'channel_1', name: 'event_name', data: { foo: 'bar' }}
+  {channel: 'channel_1', name: 'event_name', data: { foo: 'bar' }},
   {channel: 'channel_1', name: 'event_name', data: { hello: 'world' }}
 ])
 ```
@@ -146,9 +146,9 @@ Pusher['a_channel'].trigger('an_event', :some => 'data')
 
 This will continue to work, but has been replaced by `Pusher.trigger` which supports one or multiple channels.
 
-### Using the Pusher REST API
+### Using the Pusher REST API
 
-This gem provides methods for accessing information from the [Pusher REST API](https://pusher.com/docs/rest_api). The documentation also shows an example of the responses from each of the API endpionts.
+This gem provides methods for accessing information from the [Pusher REST API](https://pusher.com/docs/rest_api). The documentation also shows an example of the responses from each of the API endpoints.
 
 The following methods are provided by the gem.
 
@@ -296,4 +296,3 @@ data = {
 ```
 
 **NOTE:** This is currently a BETA feature and there might be minor bugs and issues. Changes to the API will be kept to a minimum, but changes are expected. If you come across any bugs or issues, please do get in touch via [support](support@pusher.com) or create an issue here.
-

--- a/lib/pusher/channel.rb
+++ b/lib/pusher/channel.rb
@@ -146,7 +146,7 @@ module Pusher
     #   render :json => Pusher['private-my_channel'].authenticate(params[:socket_id])
     #
     # @example Presence channels
-    #   render :json => Pusher['private-my_channel'].authenticate(params[:socket_id], {
+    #   render :json => Pusher['presence-my_channel'].authenticate(params[:socket_id], {
     #     :user_id => current_user.id, # => required
     #     :user_info => { # => optional - for example
     #       :name => current_user.name,

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -127,7 +127,7 @@ module Pusher
       @connect_timeout, @send_timeout, @receive_timeout = value, value, value
     end
 
-    ## INTERACE WITH THE API ##
+    ## INTERACT WITH THE API ##
 
     def resource(path)
       Resource.new(self, path)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -87,13 +87,13 @@ describe Pusher do
         expect(@client.host).to eq('api.staging.pusherapp.com')
       end
 
-      it 'should get override the url configuration if it comes after' do
+      it 'should override the url configuration if it comes after' do
         @client.url = "http://somekey:somesecret@api.staging.pusherapp.com:8080/apps/87"
         @client.cluster = 'eu'
         expect(@client.host).to eq('api-eu.pusher.com')
       end
 
-      it 'should overrie by the host configuration if it comes after' do
+      it 'should override the host configuration if it comes after' do
         @client.host = 'api.staging.pusher.com'
         @client.cluster = 'eu'
         expect(@client.host).to eq('api-eu.pusher.com')
@@ -612,4 +612,3 @@ describe Pusher do
     end
   end
 end
-


### PR DESCRIPTION
- `endpionts` now `endpoints`
- channel.rb - presence channel example now uses correct `presence-` format
- `Pusher.trigger_batch` - array items now separated using a comma
- client.rb - `INTERACE` now `INTERACT`
- client_spec.rb - Spelling of test descriptions now correct
- `Using the pusher REST API` - title markup was not rendering properly