### PR TITLE
add documentation for port override

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ If you need to make requests via a HTTP proxy then it can be configured
 Pusher.http_proxy = 'http://(user):(password)@(host):(port)'
 ```
 
-By default API requests are made over HTTP. HTTPS can be used by setting
+By default API requests are made over HTTP. HTTPS can be used by setting `encrypted` to `true`.
+Issuing this command is going to reset `port` value if it was previously specified.
 
 ``` ruby
 Pusher.encrypted = true


### PR DESCRIPTION
This was a behaviour a stumbled on that was not documented.
If you do this your port is going to be reset.
```
Pusher.port = 8080
Pusher.encrypted = false
```
If you do this all is fine:
```
Pusher.encrypted = false
Pusher.port = 8080
```
At first I wanted to fix this behaviour but then found a spec that checks for this,
so decided to at least add a warning.