### PR TITLE
Cleanup dirty state of ENV variable

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -109,6 +109,10 @@ describe Pusher do
     end
 
     describe 'configuring from env' do
+      after do
+        ENV['PUSHER_URL'] = nil
+      end
+
       it "works" do
         url = "http://somekey:somesecret@api.staging.pusherapp.com:8080/apps/87"
         ENV['PUSHER_URL'] = url
@@ -118,7 +122,6 @@ describe Pusher do
         expect(client.secret).to eq("somesecret")
         expect(client.app_id).to eq("87")
         expect(client.url.to_s).to eq("http://api.staging.pusherapp.com:8080/apps/87")
-        ENV['PUSHER_URL'] = nil
       end
     end
 


### PR DESCRIPTION
I was looking into the test suite for Client class and I found that if any of the tests fail, the state would never be cleaned up (`ENV['PUSHER_URL'] = nil`). It's better to use `after` block to _always_ clean the state.

@vivangkumar 