### PR TITLE
Refactor request.rb to handling HTTP 413

### DIFF
--- a/lib/pusher/request.rb
+++ b/lib/pusher/request.rb
@@ -94,6 +94,8 @@ module Pusher
         raise Error, "404 Not found (#{@uri.path})"
       when 407
         raise Error, "Proxy Authentication Required"
+      when 413
+        raise Error, "Payload Too Large > 10KB"
       else
         raise Error, "Unknown error (status code #{status_code}): #{body}"
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -430,6 +430,11 @@ describe Pusher do
             expect { call_api }.to raise_error(Pusher::Error, 'Proxy Authentication Required')
           end
 
+          it "should raise Pusher::Error if pusher returns 413" do
+            stub_request(verb, @url_regexp).to_return({:status => 413})
+            expect { call_api }.to raise_error(Pusher::Error, 'Payload Too Large > 10KB')
+          end
+
           it "should raise Pusher::Error if pusher returns 500" do
             stub_request(verb, @url_regexp).to_return({:status => 500, :body => "some error"})
             expect { call_api }.to raise_error(Pusher::Error, 'Unknown error (status code 500): some error')


### PR DESCRIPTION
This commit refactors the /lib/pusher/request.rb to
handling HTTP 413 payload bigger than 10kb.
Today, when this error occurs, will raise an unknown
error this does not make sense because that error
is known by the library and I think the library
should raise the specific error.