### PR TITLE
Add use_tls/encrypted config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ channels_client = Pusher::Client.new(
   key: 'your-app-key',
   secret: 'your-app-secret',
   cluster: 'your-app-cluster',
+  useTLS: true
 )
 ```
 
-The cluster value will set the `host` to `api-<cluster>.pusher.com`.
+The `cluster` value will set the `host` to `api-<cluster>.pusher.com`. The `useTLS` value is optional and defaults to `false`. It will set the `scheme` and `port`. Custom `scheme` and `port` values take precendence over `useTLS`.
 
 If you want to set a custom `host` value for your client then you can do so when instantiating a Pusher Channels client like so:
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ channels_client = Pusher::Client.new(
   key: 'your-app-key',
   secret: 'your-app-secret',
   cluster: 'your-app-cluster',
-  useTLS: true
+  use_tls: true
 )
 ```
 
-The `cluster` value will set the `host` to `api-<cluster>.pusher.com`. The `useTLS` value is optional and defaults to `false`. It will set the `scheme` and `port`. Custom `scheme` and `port` values take precendence over `useTLS`.
+The `cluster` value will set the `host` to `api-<cluster>.pusher.com`. The `use_tls` value is optional and defaults to `false`. It will set the `scheme` and `port`. Custom `scheme` and `port` values take precendence over `use_tls`.
 
 If you want to set a custom `host` value for your client then you can do so when instantiating a Pusher Channels client like so:
 

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -28,7 +28,7 @@ module Pusher
         :port => 80,
       }
 
-      if options[:useTLS] || options[:encrypted]
+      if options[:use_tls] || options[:encrypted]
         default_options[:scheme] = "https"
         default_options[:port] = 443
       end

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -27,6 +27,12 @@ module Pusher
         :scheme => 'http',
         :port => 80,
       }
+
+      if options[:useTLS] || options[:encrypted]
+        default_options[:scheme] = "https"
+        default_options[:port] = 443
+      end
+
       merged_options = default_options.merge(options)
 
       if options.has_key?(:host)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -100,6 +100,40 @@ describe Pusher do
       end
     end
 
+    describe 'configuring TLS' do
+      it 'should set port and scheme if "useTLS" enabled' do
+        client = Pusher::Client.new({
+          :useTLS => true,
+        })
+        expect(client.scheme).to eq('https')
+        expect(client.port).to eq(443)
+      end
+
+      it 'should set port and scheme if "encrypted" enabled' do
+        client = Pusher::Client.new({
+          :encrypted => true,
+        })
+        expect(client.scheme).to eq('https')
+        expect(client.port).to eq(443)
+      end
+
+      it 'should use non-TLS port and scheme if "encrypted" or "useTLS" are not set' do
+        client = Pusher::Client.new
+        expect(client.scheme).to eq('http')
+        expect(client.port).to eq(80)
+      end
+
+      it 'should override port if "useTLS" option set but a different port is specified' do
+        client = Pusher::Client.new({
+          :useTLS => true,
+          :port => 8443
+        })
+        expect(client.scheme).to eq('https')
+        expect(client.port).to eq(8443)
+      end
+
+    end
+
     describe 'configuring a http proxy' do
       it "should be possible to configure everything by setting the http_proxy" do
         @client.http_proxy = 'http://someuser:somepassword@proxy.host.com:8080'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -101,9 +101,9 @@ describe Pusher do
     end
 
     describe 'configuring TLS' do
-      it 'should set port and scheme if "useTLS" enabled' do
+      it 'should set port and scheme if "use_tls" enabled' do
         client = Pusher::Client.new({
-          :useTLS => true,
+          :use_tls => true,
         })
         expect(client.scheme).to eq('https')
         expect(client.port).to eq(443)
@@ -117,15 +117,15 @@ describe Pusher do
         expect(client.port).to eq(443)
       end
 
-      it 'should use non-TLS port and scheme if "encrypted" or "useTLS" are not set' do
+      it 'should use non-TLS port and scheme if "encrypted" or "use_tls" are not set' do
         client = Pusher::Client.new
         expect(client.scheme).to eq('http')
         expect(client.port).to eq(80)
       end
 
-      it 'should override port if "useTLS" option set but a different port is specified' do
+      it 'should override port if "use_tls" option set but a different port is specified' do
         client = Pusher::Client.new({
-          :useTLS => true,
+          :use_tls => true,
           :port => 8443
         })
         expect(client.scheme).to eq('https')


### PR DESCRIPTION
This adds the `use_tls` (and `encrypted`) options to the client constructor, to make this library consistent with other server libraries.