### PR TITLE
Add 1.3.2 and 1.3.3 to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+1.3.3 / 2019-07-02
+==================
+
+  * Rewording to clarify "Pusher Channels" or simply "Channels" product name.
+
+1.3.2 / 2018-10-17
+==================
+
+  * Return a specific error for "Request Entity Too Large" (body over 10KB).
+  * Add a `use_tls` option for SSL (defaults to false).
+  * Add a `from_url` client method (in addition to existing `from_env` option).
+  * Improved documentation and fixed typos.
+  * Add Ruby 2.4 to test matrix.
+
 1.3.1 / 2017-03-15
 ==================
 
@@ -100,4 +114,3 @@ First release with a changelog !
 
   * Bump httpclient to v2.4. See #62 (POODLE SSL)
   * Fix limited channel count at README.md. Thanks @tricknotes
-


### PR DESCRIPTION
Closes #146.

I find changelogs helpful, sometimes you discover an exciting new feature, or are just reassured that there wasn't any breaking change.

I used the [commit diff](https://github.com/pusher/pusher-http-ruby/compare/v1.3.1...v1.3.2) between tags for 1.3.1 to 1.3.2.
For 1.3.2 to 1.3.3 (which isn't tagged) I used @rafbm's [diff](https://gist.github.com/rafbm/6a2ecc928132f210ff71fb48db599a90).

In each case, summarised similar items and inclused anything that seemed to be of note. Dates were taken from [Rubygems](https://rubygems.org/gems/pusher).