### PR TITLE
Don't add `rbnacl` as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,13 @@ end
 
 This library supports [end-to-end encrypted channels](https://pusher.com/docs/channels/using_channels/encrypted-channels). This means that only you and your connected clients will be able to read your messages. Pusher cannot decrypt them. You can enable this feature by following these steps:
 
-1. Install [Libsodium](https://github.com/jedisct1/libsodium), which we rely on to do the heavy lifting. [Follow the installation instructions for your platform.](https://github.com/RubyCrypto/rbnacl/wiki/Installing-libsodium)
+1. Add the `rbnacl` gem to your Gemfile (it's not a gem dependency).
 
-2. Encrypted channel subscriptions must be authenticated in the exact same way as private channels. You should therefore [create an authentication endpoint on your server](https://pusher.com/docs/authenticating_users).
+2. Install [Libsodium](https://github.com/jedisct1/libsodium), which we rely on to do the heavy lifting. [Follow the installation instructions for your platform.](https://github.com/RubyCrypto/rbnacl/wiki/Installing-libsodium)
 
-3. Next, generate your 32 byte master encryption key, encode it as base64 and pass it to the Pusher constructor.
+3. Encrypted channel subscriptions must be authenticated in the exact same way as private channels. You should therefore [create an authentication endpoint on your server](https://pusher.com/docs/authenticating_users).
+
+4. Next, generate your 32 byte master encryption key, encode it as base64 and pass it to the Pusher constructor.
 
    This is secret and you should never share this with anyone.
    Not even Pusher.
@@ -276,9 +278,9 @@ This library supports [end-to-end encrypted channels](https://pusher.com/docs/ch
    });
    ```
 
-4. Channels where you wish to use end-to-end encryption should be prefixed with `private-encrypted-`.
+5. Channels where you wish to use end-to-end encryption should be prefixed with `private-encrypted-`.
 
-5. Subscribe to these channels in your client, and you're done! You can verify it is working by checking out the debug console on the [https://dashboard.pusher.com/](dashboard) and seeing the scrambled ciphertext.
+6. Subscribe to these channels in your client, and you're done! You can verify it is working by checking out the debug console on the [https://dashboard.pusher.com/](dashboard) and seeing the scrambled ciphertext.
 
 **Important note: This will __not__ encrypt messages on channels that are not prefixed by `private-encrypted-`.**
 

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -467,7 +467,7 @@ module Pusher
 
       # Only now load rbnacl, so that people that aren't using it don't need to
       # install libsodium
-      require 'rbnacl'
+      require_rbnacl
 
       secret_box = RbNaCl::SecretBox.new(
         RbNaCl::Hash.sha256(channel + @encryption_master_key)
@@ -484,6 +484,13 @@ module Pusher
 
     def configured?
       host && scheme && key && secret && app_id
+    end
+
+    def require_rbnacl
+      require 'rbnacl'
+    rescue LoadError => e
+      $stderr.puts "You don't have rbnacl installed in your application. Please add it to your Gemfile and run bundle install"
+      raise e
     end
   end
 end

--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'pusher-signature', "~> 0.1.8"
   s.add_dependency "httpclient", "~> 2.8"
   s.add_dependency "jruby-openssl" if defined?(JRUBY_VERSION)
-  s.add_dependency "rbnacl", "~> 7.1"
 
   s.add_development_dependency "rspec", "~> 3.9"
   s.add_development_dependency "webmock", "~> 3.9"
@@ -26,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rack", "~> 2.2"
   s.add_development_dependency "json", "~> 2.3"
+  s.add_development_dependency "rbnacl", "~> 7.1"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Some gems, such as `ruby-jwt`, try to load `rbnacl` when library loaded.
https://github.com/jwt/ruby-jwt/blob/0f7dd575a3324a4aefe769a1f7d381efe2141771/lib/jwt/signature.rb#L11-L15

Because of this, if `rbnacl` exists in dependencies, cause of `libsodium` load error.

Therefore, it is better to have it specified in the user's `Gemfile` instead of making it dependency of gem.

Fixes #161.