### PR TITLE
Authentication for encrypted channels

### DIFF
--- a/lib/pusher/channel.rb
+++ b/lib/pusher/channel.rb
@@ -174,6 +174,15 @@ module Pusher
       r
     end
 
+    def shared_secret(encryption_master_key)
+      return unless encryption_master_key
+
+      secret_string = @name + encryption_master_key
+      digest = OpenSSL::Digest::SHA256.new
+      digest << secret_string
+      Base64.strict_encode64(digest.digest)
+    end
+
     private
 
     def validate_socket_id(socket_id)

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -375,7 +375,11 @@ module Pusher
     #
     def authenticate(channel_name, socket_id, custom_data = nil)
       channel_instance = channel(channel_name)
-      channel_instance.authenticate(socket_id, custom_data)
+      r = channel_instance.authenticate(socket_id, custom_data)
+      if channel_name.match(/^private-encrypted-/)
+        r[:shared_secret] = channel_instance.shared_secret(encryption_master_key)
+      end
+      r
     end
 
     # @private Construct a net/http http client

--- a/spec/channel_spec.rb
+++ b/spec/channel_spec.rb
@@ -167,4 +167,21 @@ describe Pusher::Channel do
       }.to raise_error Pusher::Error
     end
   end
+
+  describe `#shared_secret` do
+    before(:each) do
+      @channel.instance_variable_set(:@name, 'private-encrypted-1')
+    end
+
+    it 'should return a shared_secret based on the channel name and encryption master key' do
+      key = '3W1pfB/Etr+ZIlfMWwZP3gz8jEeCt4s2pe6Vpr+2c3M='
+      shared_secret = @channel.shared_secret(key)
+      expect(shared_secret).to eq("6zeEp/chneRPS1cbK/hGeG860UhHomxSN6hTgzwT20I=")
+    end
+
+    it 'should return nil if missing encryption master key' do
+      shared_secret = @channel.shared_secret(nil)
+      expect(shared_secret).to be_nil
+    end
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -276,6 +276,19 @@ describe Pusher do
           })
         end
 
+        it 'should include a shared_secret if the private-encrypted channel' do
+          allow(MultiJson).to receive(:encode).with(@custom_data).and_return 'a json string'
+          @client.instance_variable_set(:@encryption_master_key, '3W1pfB/Etr+ZIlfMWwZP3gz8jEeCt4s2pe6Vpr+2c3M=')
+
+          response = @client.authenticate('private-encrypted-test_channel', '1.1', @custom_data)
+
+          expect(response).to eq({
+            :auth => "12345678900000001:#{hmac(@client.secret, "1.1:private-encrypted-test_channel:a json string")}",
+            :shared_secret => "o0L3QnIovCeRC8KTD8KBRlmi31dGzHVS2M93uryqDdw=",
+            :channel_data => 'a json string'
+          })
+        end
+
       end
 
       describe '#trigger' do


### PR DESCRIPTION
The http-ruby gem currently has the ability to transmit encrypted messages but not the ability to authenticate an encrypted channels. These channels subscriptions needs to include a step that generates and packages the shared secret that the client will use to decrypt any future messages on that channel.

This PR adds some simple methods and logic to pass the `shared_secret` attribute to the frontend in the case that the channel is prefixed with the `encrypted` keyword.

Only in the instance where the channel name has the `private-encrypted` prefix will the `shared_secret` key be generated/included. Additionally in the instance there is no `encryption_master_key` instance variable but the channel is prefixed with encrypted the gem will return nil for the `shared_secret` attribute.