### PR TITLE
use strict base64 variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+==========
+
+  * Remove newline from end of base64 encoded strings, some decoders don't like
+    them.
+
 1.4.2 / 2020-10-20
 ==================
 

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -59,7 +59,7 @@ module Pusher
 
       if options.has_key?(:encryption_master_key_base64)
         @encryption_master_key =
-          Base64.decode64(options[:encryption_master_key_base64])
+          Base64.strict_decode64(options[:encryption_master_key_base64])
       end
 
       @http_proxy = nil
@@ -148,7 +148,7 @@ module Pusher
     # Set an encryption_master_key to use with private-encrypted channels from
     # a base64 encoded string.
     def encryption_master_key_base64=(s)
-      @encryption_master_key = s ? Base64.decode64(s) : nil
+      @encryption_master_key = s ? Base64.strict_decode64(s) : nil
     end
 
     ## INTERACT WITH THE API ##
@@ -483,8 +483,8 @@ module Pusher
       ciphertext = secret_box.encrypt(nonce, encoded_data)
 
       MultiJson.encode({
-        "nonce" => Base64::encode64(nonce),
-        "ciphertext" => Base64::encode64(ciphertext),
+        "nonce" => Base64::strict_encode64(nonce),
+        "ciphertext" => Base64::strict_encode64(ciphertext),
       })
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -385,8 +385,8 @@ describe Pusher do
             )
 
             expect(MultiJson.decode(RbNaCl::SecretBox.new(key).decrypt(
-              Base64.decode64(data["nonce"]),
-              Base64.decode64(data["ciphertext"]),
+              Base64.strict_decode64(data["nonce"]),
+              Base64.strict_decode64(data["ciphertext"]),
             ))).to eq({ 'some' => 'data' })
           }
         end
@@ -461,8 +461,8 @@ describe Pusher do
             )
 
             expect(MultiJson.decode(RbNaCl::SecretBox.new(key).decrypt(
-              Base64.decode64(data["nonce"]),
-              Base64.decode64(data["ciphertext"]),
+              Base64.strict_decode64(data["nonce"]),
+              Base64.strict_decode64(data["ciphertext"]),
             ))).to eq({ 'some' => 'data' })
 
             expect(batch[1]["channel"]).to eq("mychannel")


### PR DESCRIPTION
The JS SDK chokes on base64 which ends in a newline, using the strict variants fixes this (and seems to be a good idea in general anyway).