### PR TITLE
Remove example config from .github/workflows/test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ jobs:
 
     name: Ruby ${{ matrix.ruby }} Test
 
-    env:
-      DAY_OF_WEEK: Mon
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
I accidentally didn't remove this in https://github.com/pusher/pusher-http-ruby/pull/165.