### PR TITLE
Add release actions, bump Ruby versions

### DIFF
--- a/.document
+++ b/.document
@@ -1,5 +1,0 @@
-README.rdoc
-lib/**/*.rb
-bin/*
-features/**/*.feature
-LICENSE

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 365
+daysUntilStale: 90
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
@@ -23,4 +23,4 @@ markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. If you'd
   like this issue to stay open please leave a comment indicating how this issue
-  is affecting you. Thankyou.
+  is affecting you. Thank you.

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,35 @@
+name: Github Release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup git
+        run: |
+          git config user.email "pusher-ci@pusher.com"
+          git config user.name "Pusher CI"
+      - name: Prepare description
+        run: |
+          csplit -s CHANGELOG.md "/##/" {1}
+          cat xx01 > CHANGELOG.tmp
+      - name: Prepare tag
+        run: |
+          export TAG=$(head -1 CHANGELOG.tmp | cut -d' ' -f2)
+          echo "TAG=$TAG" >> $GITHUB_ENV
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.TAG }}
+          release_name: ${{ env.TAG }}
+          body_path: CHANGELOG.tmp
+          draft: false
+          prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: RubyGems release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Publish gem
+        uses: dawidd6/action-publish-gem@v1
+        with:
+          api_key: ${{secrets.RUBYGEMS_API_KEY}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  pull_request:
+    types: [ labeled ]
+    branches:
+      - master
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set major release
+        if: ${{ github.event.label.name == 'release-major' }}
+        run: echo "RELEASE=major" >> $GITHUB_ENV
+      - name: Set minor release
+        if: ${{ github.event.label.name == 'release-minor' }}
+        run: echo "RELEASE=minor" >> $GITHUB_ENV
+      - name: Set patch release
+        if: ${{ github.event.label.name == 'release-patch' }}
+        run: echo "RELEASE=patch" >> $GITHUB_ENV
+      - name: Check release env
+        run: |
+          if [[ -z "${{ env.RELEASE }}" ]];
+          then
+            echo "You need to set a release label on PRs to the main branch"
+            exit 1
+          else
+            exit 0
+          fi
+      - name: Install semver-tool
+        run: |
+          export DIR=$(mktemp -d)
+          cd $DIR
+          curl https://github.com/fsaintjacques/semver-tool/archive/3.2.0.tar.gz -L -o semver.tar.gz
+          tar -xvf semver.tar.gz
+          sudo cp semver-tool-3.2.0/src/semver /usr/local/bin
+      - name: Bump version
+        run: |
+          export CURRENT=$(gem info pusher-push-notifications --remote --exact | grep -o "pusher-push-notifications ([0-9]*\.[0-9]*\.[0-9]*)" | awk -F '[()]' '{print $2}')
+          export NEW_VERSION=$(semver bump ${{ env.RELEASE }} $CURRENT)
+          echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup git
+        run: |
+          git config user.email "pusher-ci@pusher.com"
+          git config user.name "Pusher CI"
+          git fetch
+          git checkout ${{ github.event.pull_request.head.ref }}
+      - name: Prepare CHANGELOG
+        run: |
+          echo "${{ github.event.pull_request.body }}" | csplit -s - "/##/"
+          echo "# Changelog
+
+          ## ${{ env.VERSION }}
+          " >> CHANGELOG.tmp
+          grep "^*" xx01 >> CHANGELOG.tmp
+          grep -v "^# " CHANGELOG.md >> CHANGELOG.tmp
+          cp CHANGELOG.tmp CHANGELOG.md
+      - name: Prepare version.rb
+        run: |
+          sed -i "s|VERSION = '[^']*'|VERSION = '${{ env.VERSION }}'|" lib/pusher/version.rb
+      - name: Prepare Gemfile.lock
+        run: |
+          sed -i "s|pusher-push-notifications ([^)]*)|pusher-push-notifications (${{ env.VERSION }})|" Gemfile.lock
+      - name: Commit changes
+        run: |
+          git add CHANGELOG.md lib/pusher/push_notifications/version.rb Gemfile.lock
+          git commit -m "Bump to version ${{ env.VERSION }}"
+      - name: Push
+        run: git push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6' ]
+        ruby: ['2.6', '2.7', '3.0']
 
     name: Ruby ${{ matrix.ruby }} Test
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Gem provides a Ruby interface to [the Pusher HTTP API for Pusher Channels](
 
 ## Supported Platforms
 
-* Ruby - supports **Ruby 2.4 or greater**.
+* Ruby - supports **Ruby 2.6 or greater**.
 
 ## Installation and Configuration
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+
+Add a short description of the change. If this is related to an issue, please add a reference to the issue.
+
+## CHANGELOG
+
+* [CHANGED] Describe your change here. Look at CHANGELOG.md to see the format.

--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.description = %q{Wrapper for Pusher Channels REST api: : https://pusher.com/channels}
   s.license     = "MIT"
 
+  s.required_ruby_version = ">= 2.6"
+
   s.add_dependency "multi_json", "~> 1.15"
   s.add_dependency 'pusher-signature', "~> 0.1.8"
   s.add_dependency "httpclient", "~> 2.8"


### PR DESCRIPTION
## Description

Adds Github actions for "automated" releases in line with other Pusher SDK repos. Also standardises the Changelog format in line with other repos and actions.

## CHANGELOG

* [REMOVED] Support for Ruby 2.5 and below.
* [REMOVED] Legacy push notification references.