### PR TITLE
Use TLS by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           sudo cp semver-tool-3.2.0/src/semver /usr/local/bin
       - name: Bump version
         run: |
-          export CURRENT=$(gem info pusher-push-notifications --remote --exact | grep -o "pusher-push-notifications ([0-9]*\.[0-9]*\.[0-9]*)" | awk -F '[()]' '{print $2}')
+          export CURRENT=$(gem info pusher --remote --exact | grep -o "pusher ([0-9]*\.[0-9]*\.[0-9]*)" | awk -F '[()]' '{print $2}')
           export NEW_VERSION=$(semver bump ${{ env.RELEASE }} $CURRENT)
           echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
       - name: Checkout code
@@ -63,12 +63,9 @@ jobs:
       - name: Prepare version.rb
         run: |
           sed -i "s|VERSION = '[^']*'|VERSION = '${{ env.VERSION }}'|" lib/pusher/version.rb
-      - name: Prepare Gemfile.lock
-        run: |
-          sed -i "s|pusher-push-notifications ([^)]*)|pusher-push-notifications (${{ env.VERSION }})|" Gemfile.lock
       - name: Commit changes
         run: |
-          git add CHANGELOG.md lib/pusher/push_notifications/version.rb Gemfile.lock
+          git add CHANGELOG.md lib/pusher/version.rb
           git commit -m "Bump to version ${{ env.VERSION }}"
       - name: Push
         run: git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,139 +1,113 @@
-1.4.3 / 2020-10-28
-==================
+# Changelog
 
-  * Remove newline from end of base64 encoded strings, some decoders don't like
+## 1.4.3
+
+  * [FIXED] Remove newline from end of base64 encoded strings, some decoders don't like
     them.
 
-1.4.2 / 2020-10-20
+## 1.4.2
 ==================
 
-  * Return `shared_secret` to support authenticating encrypted channels. Thanks
+  * [FIXED] Return `shared_secret` to support authenticating encrypted channels. Thanks
     @Benjaminpjacobs
 
-1.4.1 / 2020-10-05
-==================
+## 1.4.1
 
-  * Remove rbnacl from dependencies so we don't get errors when it isn't
+  * [CHANGED] Remove rbnacl from dependencies so we don't get errors when it isn't
     required. Thanks @y-yagi!
 
-1.4.0 / 2020-09-29
-==================
+## 1.4.0
 
-  * Support for end-to-end encryption.
+  * [ADDED] Support for end-to-end encryption.
 
-1.3.3 / 2019-07-02
-==================
+## 1.3.3
 
-  * Rewording to clarify "Pusher Channels" or simply "Channels" product name.
+  * [CHANGED] Rewording to clarify "Pusher Channels" or simply "Channels" product name.
 
-1.3.2 / 2018-10-17
-==================
+## 1.3.2
 
-  * Return a specific error for "Request Entity Too Large" (body over 10KB).
-  * Add a `use_tls` option for SSL (defaults to false).
-  * Add a `from_url` client method (in addition to existing `from_env` option).
-  * Improved documentation and fixed typos.
-  * Add Ruby 2.4 to test matrix.
+  * [FIXED] Return a specific error for "Request Entity Too Large" (body over 10KB).
+  * [ADDED] Add a `use_tls` option for SSL (defaults to false).
+  * [ADDED] Add a `from_url` client method (in addition to existing `from_env` option).
+  * [CHANGED] Improved documentation and fixed typos.
+  * [ADDED] Add Ruby 2.4 to test matrix.
 
-1.3.1 / 2017-03-15
-==================
+## 1.3.1
 
-  * Added missing client batch methods to default client delegations
-  * Document raised exception in the `authenticate` method
-  * Fixes em-http-request from using v2.5.0 of `addressable` breaking builds.
+  * [FIXED] Added missing client batch methods to default client delegations
+  * [CHANGED] Document raised exception in the `authenticate` method
+  * [FIXED] Fixes em-http-request from using v2.5.0 of `addressable` breaking builds.
 
-1.3.0 / 2016-08-23
-==================
+## 1.3.0
 
-  * Add support for sending push notifications on up to 10 interests.
+  * [ADDED] Add support for sending push notifications on up to 10 interests.
 
-1.2.1 / 2016-08-22
-==================
+## 1.2.1
 
-  * Fixes Rails 5 compatibility. Use duck-typing to detect request object
+  * [FIXED] Fixes Rails 5 compatibility. Use duck-typing to detect request object
 
-1.2.0 / 2016-08-15
-==================
+## 1.2.0
 
-  * Minor release for Native notifications
+  * [CHANGED] Minor release for Native notifications
 
-1.2.0.rc1 / 2016-07-18
-==================
+## 1.2.0.rc1
 
-  * Add support for Native notifications
+  * [ADDED] Add support for Native notifications
 
-1.1.0 / 2016-05-20
-==================
+## 1.1.0
 
-  * Add support for batch events
+  * [ADDED] Add support for batch events
 
-1.0.0 / 2016-05-19
-==================
+## 1.0.0
 
-No breaking changes, this release is just to follow semver and show that we
+ * [CHANGED] No breaking changes, this release is just to follow semver and show that we
 are stable.
 
-0.18.0 / 2016-05-15
-==================
+## 0.18.0
 
-  * Introduce `Pusher::Client.from_env`
-  * Improve error handling on missing config
+  * [ADDED] Introduce `Pusher::Client.from_env`
+  * [FIXED] Improve error handling on missing config
 
-0.17.0 / 2016-02-22
-==================
+## 0.17.0
 
-  * Introduce the `cluster` option.
+  * [ADDED] Introduce the `cluster` option.
 
-0.16.0 / 2016-01-21
-==================
+## 0.16.0
 
-  * Bump httpclient version to 2.7
-  * Ruby 1.8.7 is not supported anymore.
+  * [CHANGED] Bump httpclient version to 2.7
+  * [REMOVED] Ruby 1.8.7 is not supported anymore.
 
-0.15.2 / 2015-12-03
-==================
+## 0.15.2
 
-  * Documented `Pusher.channel_info`, `Pusher.channels`
-  * Added `Pusher.channel_users`
+  * [CHANGED] Documented `Pusher.channel_info`, `Pusher.channels`
+  * [ADDED] Added `Pusher.channel_users`
 
-0.15.1 / 2015-11-03
-==================
+## 0.15.1
 
-  * Fixed a bug where the `authenticate` method added in 0.15.0 wasn't exposed on the Pusher class.
+  * [FIXED] Fixed a bug where the `authenticate` method added in 0.15.0 wasn't exposed on the Pusher class.
 
-0.15.0 / 2015-11-02
-==================
+## 0.15.0
 
-  * Added `Pusher.authenticate` method for authenticating private and presence channels.
+  * [ADDED] Added `Pusher.authenticate` method for authenticating private and presence channels.
     This is prefered over the older `Pusher['a_channel'].authenticate(...)` style.
 
-0.14.6 / 2015-09-29
-==================
-  * Updated to use the `pusher-signature` gem instead of `signature`.
+## 0.14.6
+
+  * [CHANGED] Updated to use the `pusher-signature` gem instead of `signature`.
     This resolves namespace related issues.
 
-0.14.5 / 2015-05-11
-==================
+## 0.14.5
 
-  * SECURITY: Prevent auth delegation trough crafted socket IDs
+  * [SECURITY] Prevent auth delegation trough crafted socket IDs
 
-0.14.4 / 2015-01-20
-==================
+## 0.14.4
 
-  * SECURITY: Prevent timing attack, update signature to v0.1.8
-  * SECURITY: Prevent POODLE. Disable SSLv3, update httpclient to v2.5
-  * Fix channel name character limit.
-  * Adds support for listing users on a presence channel
+  * [SECURITY] Prevent timing attack, update signature to v0.1.8
+  * [SECURITY] Prevent POODLE. Disable SSLv3, update httpclient to v2.5
+  * [FIXED] Fix channel name character limit.
+  * [ADDED] Adds support for listing users on a presence channel
 
-0.14.3 / 2015-01-20
-==================
+## 0.14.2
 
-Yanked, bad release
-
-0.14.2 / 2014-10-16
-==================
-
-First release with a changelog !
-
-  * Bump httpclient to v2.4. See #62 (POODLE SSL)
-  * Fix limited channel count at README.md. Thanks @tricknotes
+  * [CHANGED] Bump httpclient to v2.4. See #62 (POODLE SSL)
+  * [CHANGED] Fix limited channel count at README.md. Thanks @tricknotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.0
+
+* [CHANGED] Use TLS by default.
+* [REMOVED] Support for Ruby 2.4 and 2.5.
+* [FIXED] Handle empty or nil  configuration.
+* [REMOVED] Legacy Push Notification integration.
+* [ADDED] Stalebot and Github actions. 
+
 ## 1.4.3
 
   * [FIXED] Remove newline from end of base64 encoded strings, some decoders don't like

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -29,12 +29,16 @@ module Pusher
     end
 
     def initialize(options = {})
-      @scheme = "http"
-      @port = options[:port] || 80
+      @scheme = "https"
+      @port = options[:port] || 443
 
-      if options[:use_tls] || options[:encrypted]
-        @scheme = "https"
-        @port = options[:port] || 443
+      if options.key?(:encrypted)
+        warn "[DEPRECATION] `encrypted` is deprecated and will be removed in the next major version. Use `use_tls` instead."
+      end
+
+      if options[:use_tls] == false || options[:encrypted] == false
+        @scheme = "http"
+        @port = options[:port] || 80
       end
 
       @app_id = options[:app_id]

--- a/lib/pusher/version.rb
+++ b/lib/pusher/version.rb
@@ -1,3 +1,3 @@
 module Pusher
-  VERSION = '1.4.3'
+  VERSION = '2.0.0'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -20,8 +20,8 @@ describe Pusher do
         expect(@client.host).to eq('api-mt1.pusher.com')
       end
 
-      it 'should be preconfigured for port 80' do
-        expect(@client.port).to eq(80)
+      it 'should be preconfigured for port 443' do
+        expect(@client.port).to eq(443)
       end
 
       it 'should use standard logger if no other logger if defined' do
@@ -116,26 +116,26 @@ describe Pusher do
     end
 
     describe 'configuring TLS' do
-      it 'should set port and scheme if "use_tls" enabled' do
+      it 'should set port and scheme if "use_tls" disabled' do
         client = Pusher::Client.new({
-          :use_tls => true,
+          :use_tls => false,
         })
-        expect(client.scheme).to eq('https')
-        expect(client.port).to eq(443)
-      end
-
-      it 'should set port and scheme if "encrypted" enabled' do
-        client = Pusher::Client.new({
-          :encrypted => true,
-        })
-        expect(client.scheme).to eq('https')
-        expect(client.port).to eq(443)
-      end
-
-      it 'should use non-TLS port and scheme if "encrypted" or "use_tls" are not set' do
-        client = Pusher::Client.new
         expect(client.scheme).to eq('http')
         expect(client.port).to eq(80)
+      end
+
+      it 'should set port and scheme if "encrypted" disabled' do
+        client = Pusher::Client.new({
+          :encrypted => false,
+        })
+        expect(client.scheme).to eq('http')
+        expect(client.port).to eq(80)
+      end
+
+      it 'should use TLS port and scheme if "encrypted" or "use_tls" are not set' do
+        client = Pusher::Client.new
+        expect(client.scheme).to eq('https')
+        expect(client.port).to eq(443)
       end
 
       it 'should override port if "use_tls" option set but a different port is specified' do
@@ -145,6 +145,15 @@ describe Pusher do
         })
         expect(client.scheme).to eq('https')
         expect(client.port).to eq(8443)
+      end
+
+      it 'should override port if "use_tls" option set but a different port is specified' do
+        client = Pusher::Client.new({
+          :use_tls => false,
+          :port => 8000
+        })
+        expect(client.scheme).to eq('http')
+        expect(client.port).to eq(8000)
       end
 
     end
@@ -535,15 +544,15 @@ describe Pusher do
 
           let(:call_api) { @client.send(verb, '/path') }
 
-          it "should use http by default" do
+          it "should use https by default" do
             call_api
-            expect(WebMock).to have_requested(verb, %r{http://api-mt1.pusher.com/apps/20/path})
+            expect(WebMock).to have_requested(verb, %r{https://api-mt1.pusher.com/apps/20/path})
           end
 
           it "should use https if configured" do
-            @client.encrypted = true
+            @client.encrypted = false
             call_api
-            expect(WebMock).to have_requested(verb, %r{https://api-mt1.pusher.com})
+            expect(WebMock).to have_requested(verb, %r{http://api-mt1.pusher.com})
           end
 
           it "should format the respose hash with symbols at first level" do
@@ -622,15 +631,15 @@ describe Pusher do
               }
             }
 
-            it "should use http by default" do
+            it "should use https by default" do
               call_api
-              expect(WebMock).to have_requested(verb, %r{http://api-mt1.pusher.com/apps/20/path})
+              expect(WebMock).to have_requested(verb, %r{https://api-mt1.pusher.com/apps/20/path})
             end
 
-            it "should use https if configured" do
-              @client.encrypted = true
+            it "should use http if configured" do
+              @client.encrypted = false
               call_api
-              expect(WebMock).to have_requested(verb, %r{https://api-mt1.pusher.com})
+              expect(WebMock).to have_requested(verb, %r{http://api-mt1.pusher.com})
             end
 
             # Note that the raw httpclient connection object is returned and
@@ -657,20 +666,20 @@ describe Pusher do
 
             let(:call_api) { @client.send(method, '/path') }
 
-            it "should use http by default" do
+            it "should use https by default" do
               EM.run {
                 call_api.callback {
-                  expect(WebMock).to have_requested(verb, %r{http://api-mt1.pusher.com/apps/20/path})
+                  expect(WebMock).to have_requested(verb, %r{https://api-mt1.pusher.com/apps/20/path})
                   EM.stop
                 }
               }
             end
 
-            it "should use https if configured" do
+            it "should use http if configured" do
               EM.run {
-                @client.encrypted = true
+                @client.encrypted = false
                 call_api.callback {
-                  expect(WebMock).to have_requested(verb, %r{https://api-mt1.pusher.com})
+                  expect(WebMock).to have_requested(verb, %r{http://api-mt1.pusher.com})
                   EM.stop
                 }
               }


### PR DESCRIPTION
## Description

Any major version now switches to use TLS by default. It's 2021 after all. This will be the final PR before preparing the major version bump, hence the longer changelog below.

The full diff between the last tag is here: https://github.com/pusher/pusher-http-ruby/compare/v1.4.3...ssl_is_default?expand=1

## CHANGELOG

* [CHANGED] Use TLS by default.
* [REMOVED] Support for Ruby 2.4 and 2.5.
* [FIXED] Handle empty or nil `cluster` configuration.
* [REMOVED] Legacy Push Notification integration.
* [ADDED] Stalebot and Github actions. 
