### PR TITLE
Remove needless files from packed gem

### DIFF
--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -29,8 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "json", "~> 2.3"
   s.add_development_dependency "rbnacl", "~> 7.1"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files         = `git ls-files`.split("\n").reject { |f| f.match?(%r{^(test|spec|features|\.github)/}) }
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
## Description

This change aims to reduce the packed gem size by removing needless files.

Also, this removes the `test_files` option that is not described in the gemspec documentation.
See <https://guides.rubygems.org/specification-reference/>

<details>
<summary>Changed files</summary>

Before:

```console
$ gem build && gem unpack pusher-2.0.0.gem
$ tree -a pusher-2.0.0
pusher-2.0.0
├── .github
│   ├── stale.yml
│   └── workflows
│       ├── gh-release.yml
│       ├── publish.yml
│       ├── release.yml
│       └── test.yml
├── .gitignore
├── CHANGELOG.md
├── Gemfile
├── LICENSE
├── README.md
├── Rakefile
├── examples
│   ├── async_message.rb
│   └── presence_channels
│       ├── presence_channels.rb
│       └── public
│           └── presence_channels.html
├── lib
│   ├── pusher
│   │   ├── channel.rb
│   │   ├── client.rb
│   │   ├── request.rb
│   │   ├── resource.rb
│   │   ├── version.rb
│   │   └── webhook.rb
│   └── pusher.rb
├── pull_request_template.md
├── pusher.gemspec
└── spec
    ├── channel_spec.rb
    ├── client_spec.rb
    ├── spec_helper.rb
    └── web_hook_spec.rb

8 directories, 27 files
```

After:

```console
$ gem build && gem unpack pusher-2.0.0.gem
$ tree -a pusher-2.0.0
pusher-2.0.0
├── .gitignore
├── CHANGELOG.md
├── Gemfile
├── LICENSE
├── README.md
├── Rakefile
├── examples
│   ├── async_message.rb
│   └── presence_channels
│       ├── presence_channels.rb
│       └── public
│           └── presence_channels.html
├── lib
│   ├── pusher
│   │   ├── channel.rb
│   │   ├── client.rb
│   │   ├── request.rb
│   │   ├── resource.rb
│   │   ├── version.rb
│   │   └── webhook.rb
│   └── pusher.rb
├── pull_request_template.md
└── pusher.gemspec

5 directories, 18 files
```

</details>

## CHANGELOG

* [CHANGED] Remove needless files from the packed gem.
