### PR TITLE
Only include lib and doc files in gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+* [CHANGED] Only include lib and essential docs in gem.
+
 ## 2.0.0
 
 * [CHANGED] Use TLS by default.

--- a/lib/pusher/version.rb
+++ b/lib/pusher/version.rb
@@ -1,3 +1,3 @@
 module Pusher
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -29,8 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "json", "~> 2.3"
   s.add_development_dependency "rbnacl", "~> 7.1"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir["lib/**/*"] + %w[CHANGELOG.md LICENSE README.md]
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
## Description

Only include lib and essential docs in gem. This is just a slight variation of #174. Thank you @ybiquitous!

### This is the new structure inside the gem:

```bash
$ tree pusher-2.0.0 
pusher-2.0.0
├── CHANGELOG.md
├── LICENSE
├── README.md
└── lib
    ├── pusher
    │   ├── channel.rb
    │   ├── client.rb
    │   ├── request.rb
    │   ├── resource.rb
    │   ├── version.rb
    │   └── webhook.rb
    └── pusher.rb
```

## CHANGELOG

* [CHANGED] Only include lib and essential docs in gem.
