### PR TITLE
Make encryption_master_key_base64 globally configurable 

### DIFF
--- a/lib/pusher.rb
+++ b/lib/pusher.rb
@@ -27,8 +27,10 @@ module Pusher
   class << self
     extend Forwardable
 
-    def_delegators :default_client, :scheme, :host, :port, :app_id, :key, :secret, :http_proxy
-    def_delegators :default_client, :scheme=, :host=, :port=, :app_id=, :key=, :secret=, :http_proxy=
+    def_delegators :default_client, :scheme, :host, :port, :app_id, :key,
+                   :secret, :http_proxy, :encryption_master_key_base64
+    def_delegators :default_client, :scheme=, :host=, :port=, :app_id=, :key=,
+                   :secret=, :http_proxy=, :encryption_master_key_base64=
 
     def_delegators :default_client, :authentication_token, :url, :cluster
     def_delegators :default_client, :encrypted=, :url=, :cluster=


### PR DESCRIPTION
## Description

Original issue write-up: https://github.com/pusher/pusher-http-ruby/issues/176

You currently can not configure `encryption_master_key_base64` using the global config style.

```rb
Pusher.encryption_master_key_base64 = ENV['ENCRYPTION_MASTER_KEY_BASE64']
```

The above results in:

```rb
NoMethodError: undefined method `encryption_master_key_base64=' for Pusher:Module
```

## CHANGELOG

* [CHANGED] made encryption_master_key_base64 globally configurable 
