### PR TITLE
added encryption_master_key_base64 getter and setter to the Pusher de…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+* [CHANGED] made encryption_master_key_base64 globally configurable 
+
 ## 2.0.1
 
 * [CHANGED] Only include lib and essential docs in gem.

--- a/lib/pusher.rb
+++ b/lib/pusher.rb
@@ -27,8 +27,10 @@ module Pusher
   class << self
     extend Forwardable
 
-    def_delegators :default_client, :scheme, :host, :port, :app_id, :key, :secret, :http_proxy
-    def_delegators :default_client, :scheme=, :host=, :port=, :app_id=, :key=, :secret=, :http_proxy=
+    def_delegators :default_client, :scheme, :host, :port, :app_id, :key,
+                   :secret, :http_proxy, :encryption_master_key_base64
+    def_delegators :default_client, :scheme=, :host=, :port=, :app_id=, :key=,
+                   :secret=, :http_proxy=, :encryption_master_key_base64=
 
     def_delegators :default_client, :authentication_token, :url, :cluster
     def_delegators :default_client, :encrypted=, :url=, :cluster=

--- a/lib/pusher/version.rb
+++ b/lib/pusher/version.rb
@@ -1,3 +1,3 @@
 module Pusher
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
## Description

You currently can not configure encryption_master_key_base64 using the global config style.

## CHANGELOG

* [CHANGED] made encryption_master_key_base64 globally configurable 
