### PR TITLE
Fix use_tls= writer method in module and client

### DIFF
--- a/lib/pusher.rb
+++ b/lib/pusher.rb
@@ -33,7 +33,7 @@ module Pusher
                    :secret=, :http_proxy=, :encryption_master_key_base64=
 
     def_delegators :default_client, :authentication_token, :url, :cluster
-    def_delegators :default_client, :encrypted=, :url=, :cluster=
+    def_delegators :default_client, :encrypted=, :url=, :cluster=, :use_tls=
     def_delegators :default_client, :timeout=, :connect_timeout=, :send_timeout=, :receive_timeout=, :keep_alive_timeout=
 
     def_delegators :default_client, :get, :get_async, :post, :post_async

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -118,6 +118,8 @@ module Pusher
       @port = boolean ? 443 : 80
     end
 
+    alias :use_tls :encrypted=
+
     def encrypted?
       @scheme == 'https'
     end


### PR DESCRIPTION
## Description

Although `use_tls` options was recently introduced as a future
replacement of the `encrypted` option and even added to the
documentation, the respective methods were missing at the module and
instance level.

## CHANGELOG

* [FIXED] Add missing `use_tls=` to Pusher module and client instance.
