### PR TITLE
uses media_type for MIME type in webhooks

### DIFF
--- a/lib/pusher/webhook.rb
+++ b/lib/pusher/webhook.rb
@@ -31,10 +31,10 @@ module Pusher
     def initialize(request, client = Pusher)
       @client = client
       # For Rack::Request and ActionDispatch::Request
-      if request.respond_to?(:env) && request.respond_to?(:content_type)
+      if request.respond_to?(:env) && (request.methods & [:media_type, :content_type]).any?
         @key = request.env['HTTP_X_PUSHER_KEY']
         @signature = request.env["HTTP_X_PUSHER_SIGNATURE"]
-        @content_type = request.content_type
+        @content_type = request.media_type || request.content_type
 
         request.body.rewind
         @body = request.body.read

--- a/spec/web_hook_spec.rb
+++ b/spec/web_hook_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+require 'delegate'
 require 'rack'
 require 'stringio'
 
@@ -21,6 +22,28 @@ describe Pusher::WebHook do
         'CONTENT_TYPE' => 'application/json',
         'rack.input' => StringIO.new(MultiJson.encode(@hook_data))
       })
+      wh = Pusher::WebHook.new(request)
+      expect(wh.key).to eq('1234')
+      expect(wh.signature).to eq('asdf')
+      expect(wh.data).to eq(@hook_data)
+    end
+
+    it "can be initialized with ActionDispatch::Request" do
+      ActionDispatchRequestMock = Class.new(SimpleDelegator) do
+        def mime_type
+          'application/json'
+        end
+      end
+
+      rack_request =Rack::Request.new({
+        'HTTP_X_PUSHER_KEY' => '1234',
+        'HTTP_X_PUSHER_SIGNATURE' => 'asdf',
+        'CONTENT_TYPE' => 'application/json',
+        'rack.input' => StringIO.new(MultiJson.encode(@hook_data))
+      })
+
+      request = ActionDispatchRequestMock.new(rack_request)
+
       wh = Pusher::WebHook.new(request)
       expect(wh.key).to eq('1234')
       expect(wh.signature).to eq('asdf')


### PR DESCRIPTION
## Description

As describe in this issue #179, Rails displays a warning when reading the *MIME* type with `content_type` from the `request` object. I suggest to prioritize the `media_type` when existing.

## CHANGELOG

* [CHANGED] Fix Rails 7.1 MIME type deprecation warning
