### PR TITLE
fix the channels limit for  a single publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.3
+
+* [FIXED] Corrected the channels limit when publishing events. Upped from 10 to 100. 
+
 ## 2.0.2
 
 * [CHANGED] made encryption_master_key_base64 globally configurable 

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -401,7 +401,7 @@ module Pusher
 
     def trigger_params(channels, event_name, data, params)
       channels = Array(channels).map(&:to_s)
-      raise Pusher::Error, "Too many channels (#{channels.length}), max 10" if channels.length > 10
+      raise Pusher::Error, "Too many channels (#{channels.length}), max 100" if channels.length > 100
 
       encoded_data = if channels.any?{ |c| c.match(/^private-encrypted-/) } then
         raise Pusher::Error, "Cannot trigger to multiple channels if any are encrypted" if channels.length > 1

--- a/lib/pusher/version.rb
+++ b/lib/pusher/version.rb
@@ -1,3 +1,3 @@
 module Pusher
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -326,7 +326,7 @@ describe Pusher do
 
         it "should not allow too many channels" do
           expect {
-            @client.trigger((0..11).map{|i| 'mychannel#{i}'},
+            @client.trigger((0..101).map{|i| 'mychannel#{i}'},
               'event', {'some' => 'data'}, {
                 :socket_id => "12.34"
               })}.to raise_error(Pusher::Error)


### PR DESCRIPTION
## Description

Upped the number of channels that can be passed to the trigger function from 10 to 100, to bring in line with the [documentation](https://pusher.com/docs/channels/server_api/http-api/#publishing-events:~:text=An%20event%20can%20be%20published%20to%20between%201%20and%20100%20channel%20names%20in%20a%20single%20request) and [other libraries](https://github.com/pusher/pusher-http-node/commit/4066c70fdc6d9abf1bb29ed21d7dfafd2f35e8af). 

## CHANGELOG

* [FIXED] Corrected the channels limit when publishing events. Upped from 10 to 100. 