### PR TITLE
Perform time constant HMAC verification to avoid timing attack.

### DIFF
--- a/lib/pusher/webhook.rb
+++ b/lib/pusher/webhook.rb
@@ -92,6 +92,16 @@ module Pusher
       end
     end
 
+    # Time constant string comparison
+    #
+    def secure_compare(a, b)
+      return false unless a.bytesize == b.bytesize
+      l = a.unpack "C#{a.bytesize}"
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
+    end
+
     private
 
     # Checks signature against secret and returns boolean
@@ -99,7 +109,7 @@ module Pusher
     def check_signature(secret)
       digest = OpenSSL::Digest::SHA256.new
       expected = OpenSSL::HMAC.hexdigest(digest, secret, @body)
-      if @signature == expected
+      if secure_compare(@signature, expected)
         return true
       else
         Pusher.logger.warn "Received WebHook with invalid signature: got #{@signature}, expected #{expected}"


### PR DESCRIPTION
## Description

Add a short description of the change. If this is related to an issue, please add a reference to the issue.

HMAC verification should be time constant. Default ruby string comparisons are susceptible to [timing attacks](https://en.wikipedia.org/wiki/Timing_attack).
Based on https://api.rubyonrails.org/v4.2.0/classes/ActiveSupport/SecurityUtils.html#method-c-secure_compare

Alternatively newer versions of OpenSSL also support `secure_compare`. https://github.com/ruby/openssl/pull/280/files



## CHANGELOG

* [CHANGED] Time constant HMAC verification
