### PR TITLE
Add Pusher.use_tls support

### DIFF
--- a/lib/pusher.rb
+++ b/lib/pusher.rb
@@ -34,6 +34,7 @@ module Pusher
 
     def_delegators :default_client, :authentication_token, :url, :cluster
     def_delegators :default_client, :encrypted=, :url=, :cluster=
+    def_delegators :default_client, :use_tls=, :url=, :cluster=
     def_delegators :default_client, :timeout=, :connect_timeout=, :send_timeout=, :receive_timeout=, :keep_alive_timeout=
 
     def_delegators :default_client, :get, :get_async, :post, :post_async

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -122,6 +122,14 @@ module Pusher
       @scheme == 'https'
     end
 
+    def use_tls=(boolean)
+      self.encrypted = boolean
+    end
+
+    def use_tls?
+      self.encrypted?
+    end
+
     def cluster=(cluster)
       cluster = DEFAULT_CLUSTER if cluster.nil? || cluster.empty?
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -70,7 +70,6 @@ describe Pusher do
           @client.url
         }.to raise_error(Pusher::ConfigurationError)
       end
-
     end
 
     describe 'configuring the cluster' do
@@ -156,6 +155,17 @@ describe Pusher do
         expect(client.port).to eq(8000)
       end
 
+      describe '#use_tls=' do
+        it "should set the use_tls configuration option as alias of encrypted" do
+          @client.use_tls = true
+          expect(@client.use_tls?).to eq(true)
+          expect(@client.encrypted?).to eq(true)
+
+          @client.use_tls = false
+          expect(@client.use_tls?).to eq(false)
+          expect(@client.encrypted?).to eq(false)
+        end
+      end
     end
 
     describe 'configuring a http proxy' do


### PR DESCRIPTION
## Description

Add `use_tls` to the global namespace so `Pusher.use_tls = false` will work. Fix #188 

## CHANGELOG

* [ADDED] Add the `Pusher.use_tls=` method as a global option, an alias of `Pusher.encrypted=`
* [ADDED] Add the `Pusher.use_tls?` method as a global option, an alias of `Pusher.encrypted?`
