### PR TITLE
Bump version to 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.5
+
+* [FIXED] Fix webhook content_type parsing for Rails 7.1+ using media_type
+
 ## 2.0.4
 
 * [ADDED] Add `authenticate_user` method for user authentication flow

--- a/lib/pusher/version.rb
+++ b/lib/pusher/version.rb
@@ -1,3 +1,3 @@
 module Pusher
-  VERSION = '2.0.4'
+  VERSION = '2.0.5'
 end


### PR DESCRIPTION
Bumps the gem version to 2.0.5 and updates CHANGELOG following the Rails 7.1 webhook fix merged in #198.