### PR TITLE
gemspec: require Ruby 3.1+

### DIFF
--- a/pusher.gemspec
+++ b/pusher.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Wrapper for Pusher Channels REST api: : https://pusher.com/channels}
   s.license     = "MIT"
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 3.1"
 
   s.add_dependency "multi_json", "~> 1.15"
   s.add_dependency 'pusher-signature', "~> 0.1.8"


### PR DESCRIPTION
## Description

The updated version of the gem uses Ruby 3.1+ features, so we must update the required version to prevent broken upgrades.

An example issue:

```
/opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/pusher-2.0.5/lib/pusher.rb:6:in `require': /opt/hostedtoolcache/Ruby/2.7.8/x64/lib/ruby/gems/2.7.0/gems/pusher-2.0.5/lib/pusher/client.rb:380: syntax error, unexpected ',' (SyntaxError)
      { auth:, user_data: custom_data }
```

## CHANGELOG

* [CHANGED] Ruby 3.1+ is now required.
