### PR TITLE
Reset HTTP client connection after unknown error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 2.0.6
-
-* [FIXED] Reset HTTP client connection after unknown error responses to prevent subsequent requests from failing.
-
 ## 2.0.5
 
 * [FIXED] Fix webhook content_type parsing for Rails 7.1+ using media_type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+
+* [FIXED] Reset HTTP client connection after unknown error responses to prevent subsequent requests from failing.
+
 ## 2.0.5
 
 * [FIXED] Fix webhook content_type parsing for Rails 7.1+ using media_type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.6
+
+* [FIXED] Reset HTTP client connection after unknown error responses to prevent subsequent requests from failing.
+
 ## 2.0.5
 
 * [FIXED] Fix webhook content_type parsing for Rails 7.1+ using media_type

--- a/lib/pusher/request.rb
+++ b/lib/pusher/request.rb
@@ -36,8 +36,11 @@ module Pusher
       end
 
       body = response.body ? response.body.chomp : nil
+      code = response.code.to_i
 
-      return handle_response(response.code.to_i, body)
+      http.reset_all unless [200, 202, 400, 401, 403, 404, 407, 413].include?(code)
+
+      return handle_response(code, body)
     end
 
     def send_async

--- a/lib/pusher/version.rb
+++ b/lib/pusher/version.rb
@@ -1,3 +1,3 @@
 module Pusher
-  VERSION = '2.0.5'
+  VERSION = '2.1.0'
 end

--- a/lib/pusher/version.rb
+++ b/lib/pusher/version.rb
@@ -1,3 +1,3 @@
 module Pusher
-  VERSION = '2.0.5'
+  VERSION = '2.0.6'
 end

--- a/lib/pusher/version.rb
+++ b/lib/pusher/version.rb
@@ -1,3 +1,3 @@
 module Pusher
-  VERSION = '2.0.6'
+  VERSION = '2.0.5'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -262,6 +262,50 @@ describe Pusher do
             :occupied => false,
           })
         end
+
+        it "should not reset the http client connection after a 400 error" do
+          api_path = %r{/apps/20/channels/mychannel}
+          stub_request(:get, api_path).to_return({ :status => 400, :body => "Bad request" })
+
+          http_client = @client.sync_http_client
+          expect(http_client).not_to receive(:reset_all)
+
+          expect { @client.channel_info('mychannel') }.to raise_error(Pusher::Error)
+        end
+
+        it "should reset the http client connection after an unknown error status" do
+          api_path = %r{/apps/20/channels/mychannel}
+          stub_request(:get, api_path).to_return({ :status => 500, :body => "Server error" })
+
+          http_client = @client.sync_http_client
+          expect(http_client).to receive(:reset_all).once
+
+          expect { @client.channel_info('mychannel') }.to raise_error(Pusher::Error)
+        end
+
+        it "should succeed on a subsequent request after an unknown error status" do
+          api_path = %r{/apps/20/channels/mychannel}
+          stub_request(:get, api_path)
+            .to_return({ :status => 500, :body => "Server error" })
+            .then
+            .to_return({ :status => 200, :body => MultiJson.encode({ 'occupied' => false }) })
+
+          expect { @client.channel_info('mychannel') }.to raise_error(Pusher::Error)
+          expect(@client.channel_info('mychannel')).to eq({ :occupied => false })
+        end
+
+        it "should not reset the http client connection after a successful request" do
+          api_path = %r{/apps/20/channels/mychannel}
+          stub_request(:get, api_path).to_return({
+            :status => 200,
+            :body => MultiJson.encode({ 'occupied' => false })
+          })
+
+          http_client = @client.sync_http_client
+          expect(http_client).not_to receive(:reset_all)
+
+          @client.channel_info('mychannel')
+        end
       end
 
       describe '#channel_users' do


### PR DESCRIPTION
## Summary

- Calls `reset_all` on the HTTP client after receiving an unknown/unexpected status code, ensuring subsequent requests get a clean connection
- Known response codes handled by the library (200, 202, 400, 401, 403, 404, 407, 413) are treated as clean HTTP exchanges and do not trigger a reset
- Fixes an issue where an unexpected server response could leave the connection in a state that caused the next request to fail

Thanks to @rmosolgo for reporting and following up on this.

Closes #193

## Changelog

* [FIXED] Reset HTTP client connection after unknown error responses to prevent subsequent requests from failing.