### PR TITLE
Update README with minimal ruby (3.1) and s/match/match?

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Gem provides a Ruby interface to [the Pusher HTTP API for Pusher Channels](
 
 ## Supported Platforms
 
-* Ruby - supports **Ruby 2.6 or greater**.
+* Ruby - supports **Ruby 3.1 or greater**.
 
 ## Installation and Configuration
 

--- a/lib/pusher/channel.rb
+++ b/lib/pusher/channel.rb
@@ -8,7 +8,7 @@ module Pusher
     INVALID_CHANNEL_REGEX = /[^A-Za-z0-9_\-=@,.;]/
 
     def initialize(_, name, client = Pusher)
-      if Pusher::Channel::INVALID_CHANNEL_REGEX.match(name)
+      if Pusher::Channel::INVALID_CHANNEL_REGEX.match?(name)
         raise Pusher::Error, "Illegal channel name '#{name}'"
       elsif name.length > 200
         raise Pusher::Error, "Channel name too long (limit 164 characters) '#{name}'"

--- a/lib/pusher/client.rb
+++ b/lib/pusher/client.rb
@@ -347,7 +347,7 @@ module Pusher
     def authenticate(channel_name, socket_id, custom_data = nil)
       channel_instance = channel(channel_name)
       r = channel_instance.authenticate(socket_id, custom_data)
-      if channel_name.match(/^private-encrypted-/)
+      if channel_name.match?(/^private-encrypted-/)
         r[:shared_secret] = Base64.strict_encode64(
           channel_instance.shared_secret(encryption_master_key)
         )
@@ -430,7 +430,7 @@ module Pusher
       channels = Array(channels).map(&:to_s)
       raise Pusher::Error, "Too many channels (#{channels.length}), max 100" if channels.length > 100
 
-      encoded_data = if channels.any?{ |c| c.match(/^private-encrypted-/) } then
+      encoded_data = if channels.any?{ |c| c.match?(/^private-encrypted-/) }
         raise Pusher::Error, "Cannot trigger to multiple channels if any are encrypted" if channels.length > 1
         encrypt(channels[0], encode_data(data))
       else
@@ -448,7 +448,7 @@ module Pusher
       {
         batch: events.map do |event|
           event.dup.tap do |e|
-            e[:data] = if e[:channel].match(/^private-encrypted-/) then
+            e[:data] = if e[:channel].match?(/^private-encrypted-/)
               encrypt(e[:channel], encode_data(e[:data]))
             else
               encode_data(e[:data])

--- a/lib/pusher/utils.rb
+++ b/lib/pusher/utils.rb
@@ -1,7 +1,7 @@
 module Pusher
   module Utils
     def validate_socket_id(socket_id)
-      unless socket_id && /\A\d+\.\d+\z/.match(socket_id)
+      unless socket_id && /\A\d+\.\d+\z/.match?(socket_id)
         raise Pusher::Error, "Invalid socket ID #{socket_id.inspect}"
       end
     end


### PR DESCRIPTION
## Description

In #200 the `gemspec` file was changed to enforce the requirement of a minimal version of ruby 3.1, this change was not reflected on the `README.md` which still suggest that the gem supports ruby 2.6 and above.

Took the opportunity to also change the use of `Regex#match?` instead of `Regex#match`, this change will gain a performance improvement - it was added in [ruby 2.4](https://bugs.ruby-lang.org/issues/8110), specially in `Pusher::Channel` class. If required I can open up a new PR about that.

micro-benchmark:
```ruby
# spec/benchmark.rb

require 'benchmark'
require_relative 'spec_helper'
require 'pusher'

puts Benchmark.measure {
  500_000.times do
    Pusher::Channel.new('nl', 'yo', nil)
end
```

before
```
ruby spec/benchmark.rb
  0.342884   0.000089   0.342973 (  0.344086)
```
after
```
ruby spec/benchmark.rb
  0.272801   0.000000   0.272801 (  0.273464),
```

## CHANGELOG

* [CHANGED] Change README.md to reflect the minimal version supported
* [CHANGED] use `Regex#match?` instead of `Regex#match` to improve overall performance of the gem

## Notes

I didn't add the benchmark file, I can do that if the maintainers consider it worthy
